### PR TITLE
fix: Fix Claim Verification Failing Issue and Lighthouse Issue

### DIFF
--- a/bin/opfp/src/cmd/util.rs
+++ b/bin/opfp/src/cmd/util.rs
@@ -138,6 +138,9 @@ pub struct RollupConfig {
     /// The interop activation time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interop_time: Option<u64>,
+    /// The holocene_time activation time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub holocene_time: Option<u64>,
     /// The batch inbox address.
     pub batch_inbox_address: Address,
     /// The deposit contract address.
@@ -182,6 +185,7 @@ impl From<&superchain_primitives::RollupConfig> for RollupConfig {
             fjord_time: cfg.fjord_time,
             granite_time: cfg.granite_time,
             interop_time: None,
+            holocene_time: cfg.holocene_time,
             batch_inbox_address: cfg.batch_inbox_address,
             deposit_contract_address: cfg.deposit_contract_address,
             l1_system_config_address: cfg.l1_system_config_address,
@@ -227,7 +231,7 @@ impl Into<superchain_primitives::RollupConfig> for RollupConfig {
             ecotone_time: self.ecotone_time,
             fjord_time: self.fjord_time,
             granite_time: self.granite_time,
-            holocene_time: None,
+            holocene_time: self.holocene_time,
             batch_inbox_address: self.batch_inbox_address,
             deposit_contract_address: self.deposit_contract_address,
             l1_system_config_address: self.l1_system_config_address,

--- a/devnet/standard.yaml
+++ b/devnet/standard.yaml
@@ -6,6 +6,9 @@ optimism_package:
       network_params:
         granite_time_offset: 0
 ethereum_package:
+  participants:
+  - el_type: geth
+    cl_type: teku
   network_params:
     preset: minimal
     additional_preloaded_contracts: '

--- a/justfile
+++ b/justfile
@@ -100,9 +100,9 @@ generate-fixture:
         --op-program {{ op-program }} \
         --l2-block $L2_BLOCK_NUM \
         --l1-block $L1_BLOCK_NUM \
-        --l1-rpc-url {{ "http://" + shell("kurtosis service inspect " + enclave + " el-1-geth-lighthouse | grep -- ' rpc: ' | sed 's/.*-> //'") }} \
+        --l1-rpc-url {{ "http://" + shell("kurtosis service inspect " + enclave + " el-1-geth-teku | grep -- ' rpc: ' | sed 's/.*-> //'") }} \
         --l2-rpc-url $L2_RPC_URL \
-        --beacon-url {{ shell("kurtosis service inspect " + enclave + " cl-1-lighthouse-geth | grep -- ' http: ' | sed 's/.*-> //'") }} \
+        --beacon-url {{ shell("kurtosis service inspect " + enclave + " cl-1-teku-geth | grep -- ' http: ' | sed 's/.*-> //'") }} \
         --rollup-url $ROLLUP_URL \
         --rollup-path {{ rollup-path }} \
         --genesis-path {{ genesis-path }} \
@@ -143,7 +143,7 @@ update-l2-block-gas-limit:
 
     SYSTEM_CONFIG_OWNER_PRIVATE_KEY={{ shell("cat " + wallets-path + " | jq '.[].systemConfigOwnerPrivateKey'") }}
     L1_SYSTEM_CONFIG_ADRESS={{ shell("cat " + rollup-path + " | jq '.l1_system_config_address'") }}
-    L1_RPC_URL=$(kurtosis service inspect {{ enclave }} el-1-geth-lighthouse | grep -- ' rpc: ' | sed 's/.*-> //')
+    L1_RPC_URL=$(kurtosis service inspect {{ enclave }} el-1-geth-teku | grep -- ' rpc: ' | sed 's/.*-> //')
 
     cast send \
         --private-key $SYSTEM_CONFIG_OWNER_PRIVATE_KEY \
@@ -163,6 +163,6 @@ get-l2-block-gas-limit:
     kurtosis files download {{ enclave }} op-deployer-configs
 
     L1_SYSTEM_CONFIG_ADRESS={{ shell("cat " + rollup-path + " | jq '.l1_system_config_address'") }}
-    L1_RPC_URL=$(kurtosis service inspect {{ enclave }} el-1-geth-lighthouse | grep -- ' rpc: ' | sed 's/.*-> //')
+    L1_RPC_URL=$(kurtosis service inspect {{ enclave }} el-1-geth-teku | grep -- ' rpc: ' | sed 's/.*-> //')
 
     cast call --rpc-url $L1_RPC_URL $L1_SYSTEM_CONFIG_ADRESS  "gasLimit()(uint64)"


### PR DESCRIPTION
Claim verifications are currently broken producing the following output:
```
INFO [02-10|18:43:36.907] Derivation complete: no further L1 data to process
INFO [02-10|18:43:36.907] Derivation complete: no further data to process
INFO [02-10|18:43:36.907] Derivation complete                      head=825c01..9963f1:42
INFO [02-10|18:43:36.918] Validating claim                         output=11ff6c..59ef98 claim=e18264..bc8dab
CRIT [02-10|18:43:36.918] Application failed                       err="invalid claim: claim: 0xe18264e7c31daab79e4291dc1fb0268edc74daf849e66ea6c92ad26f48bc8dab actual: 0x11ff6c7cb6a7e02ba49301870e91d169d8c94a0685d4bda91cd3afd79459ef98"
```

This is because we are not setting the holocene timestamp and it defaults to 0 (aka active at genesis) but our custom defined config does not pass it onwards to op-program. So op-program runs into an error when attempting to run it's derivation (it expects holocene data but doesnt get it)

In addition, lighthouse is currently broken, so using teku instead: https://github.com/ethpandaops/optimism-package/pull/160